### PR TITLE
Improve Github Account Link Colors

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -767,6 +767,15 @@ h4 {
     text-align: center;
 }
 
+.githubLink {
+    color: white;
+    text-decoration: underline;
+}
+
+.githubLink:hover {
+    color: #d9d9d9;
+}
+
 /*=======================================================
 			MEDIA QUERIES:
 ========================================================*/

--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@
 				You can contact us using Max@Onelang.org.
 				<br>
 				<br> &copy; One Language All Right Reserved 2010-2019
-				<br> Made By <b><a href="https://github.com/BaseMax">Max Base</a></b> and <b><a href="http://asrez.com/">Asrez</a> Group</b>
+				<br> Made By <b><a href="https://github.com/BaseMax" class="githubLink">Max Base</a></b> and <b><a href="http://asrez.com/" class="githubLink">Asrez</a> Group</b>
 				<br>
 				<small>Theme By Bakhtari Badr</small>
 			</p>


### PR DESCRIPTION
Make the color of the links for Max Base and Asrez so it's not blue links on a blue background. Changed it too white with a light gray when hovering.