### PR TITLE
Updated footer copyright to show current year

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@
 			<p>
 				You can contact us using MaxBaseCode [ @ ] gmail { DOT } com
 				<br>
-				<br> &copy; One Language All Right Reserved 2010-2019
+				<br> &copy; One Language All Right Reserved 2010-<script>document.write(new Date().getFullYear())</script>
 				<br> Made By <b><a href="https://github.com/BaseMax" class="githubLink">Max Base</a></b> and <b><a href="https://github.com/One-Language/" class="githubLink">Open source</a> contributors</b>
 				<br>
 				<small>Theme By Bakhtari Badr</small>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/19654243/119862172-db660400-bf35-11eb-9b0e-07a3cea5a9d7.png)

Now:
![image](https://user-images.githubusercontent.com/19654243/119862110-cc7f5180-bf35-11eb-8751-6bdd97b46b75.png)
