### PR TITLE
Fixed markdown lint error

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: "[BUG]"
 labels: bug, help wanted
 assignees: jbampton
-
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. Chrome, Safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. Chrome, Safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, Safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, Safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
Pre-commit check was failing due to markdown lint error rule [MD032](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md032---lists-should-be-surrounded-by-blank-lines)

Issue: [One-Language/Website/issues/27](https://github.com/One-Language/Website/issues/27)